### PR TITLE
Fixed a bug where ignore operations would operate on localpath+ignore…

### DIFF
--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -69,7 +69,7 @@ export function addConfig(configPath) {
       const fullConfig = {
         ...defaultConfig,
         ...config,
-        ignore: config.ignore.map(pattern => fillGlobPattern(pattern, configRoot)),
+        ignore: config.ignore,
         configRoot,
       };
       const triePath = getPathRelativeWorkspace(configRoot);


### PR DESCRIPTION
… pattern using fillGlobPattern() when only ignore pattern is wanted.

Original problem is when using **/node_modules or /node_modules, this pattern will not be ignored. Because the match happens between /home/user/workdir/node_modules and c:/workdir/node_modules.

In conveyer.ts,:
```
function testIgnore(target, pattern) {
  return target.indexOf(pattern) === 0 || minimatch(target, pattern);
}
```
target is "/home/user/workdir/node_modules" while pattern is "c:/workdir/**/node_modules" or "c:/workdir/node_modules"

Both target.indexOf(pattern) and minimatch(target, pattern) would fail to match the patterns.

By changing config.ignore.map(pattern => fillGlobPattern(pattern, configRoot)) to config.ignore. Target "/home/user/workdir/node_modules" can now be matched with pattern "**/node_modules" or "/node_modules", which I think is the desired behaviour.