### PR TITLE
[SFTP] Added prompt to ask user for Password if config is empty

### DIFF
--- a/src/model/Client/SFTPClient.ts
+++ b/src/model/Client/SFTPClient.ts
@@ -1,4 +1,5 @@
 import { Client } from 'ssh2';
+import * as vscode from 'vscode';
 import * as fs from 'fs';
 import RemoteClient, { IClientOption } from './RemoteClient';
 
@@ -67,7 +68,17 @@ export default class SFTPClient extends RemoteClient {
       }
 
       if (!privateKeyPath) {
-        connectWithCredential(password);
+        if(!password) {
+          vscode.window.showInputBox({
+            prompt: 'Enter Password (Press ENTER for blank)',
+            password: true
+          })
+          .then(val => {
+            connectWithCredential(val);
+          });
+        } else {
+          connectWithCredential(password);
+        }
         return;
       }
 


### PR DESCRIPTION
This is a change that I did to the extension to suit my needs. Also, I saw a request for this feature in the open issues - https://github.com/liximomo/vscode-sftp/issues/24

**Screenshots of flow:**
- User is Prompted to enter Password during SFTP connection, if he has left Password field in the `sftp.json` file. This gives the user the option to not save his password in a plain text file.
<img width="1218" alt="screen shot 2017-10-20 at 11 31 19 pm" src="https://user-images.githubusercontent.com/1595593/31835340-d2ba0e9a-b5ee-11e7-9f1b-a97fb5b15694.png">

- Entry of password is masked, and user is not asked again for that session once he enters it.
<img width="947" alt="screen shot 2017-10-20 at 11 32 28 pm" src="https://user-images.githubusercontent.com/1595593/31835394-ff614a44-b5ee-11e7-8ead-a4dc0ce5f66d.png">
