### PR TITLE
Fix typo in output message

### DIFF
--- a/src/modules/conveyer.ts
+++ b/src/modules/conveyer.ts
@@ -243,7 +243,7 @@ function _transportDir(
   }
 
   const listFiles = () => {
-    output.status.msg(`retriving directory ${fileName2Show(src)}`);
+    output.status.msg(`retrieving directory ${fileName2Show(src)}`);
     return srcFs.list(src);
   };
 


### PR DESCRIPTION
When retrieving the files, the message now states 'retrieving' instead of 'retriving'.