### PR TITLE
Hide menu items when extension isn't active

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,39 +90,44 @@
         {
           "command": "sftp.diff",
           "group": "3_compare",
-          "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsFolder"
+          "when": "sftp:enabled && explorerViewletVisible && filesExplorerFocus && !explorerResourceIsFolder"
         },
         {
           "command": "sftp.sync.remote",
           "group": "sftp.sync@1",
-          "when": "explorerResourceIsFolder"
+          "when": "sftp:enabled && explorerResourceIsFolder"
         },
         {
           "command": "sftp.sync.local",
           "group": "sftp.sync@2",
-          "when": "explorerResourceIsFolder"
+          "when": "sftp:enabled && explorerResourceIsFolder"
         },
         {
           "command": "sftp.trans.remote",
-          "group": "sftp.trans@3"
+          "group": "sftp.trans@3",
+          "when": "sftp:enabled"
         },
         {
           "command": "sftp.trans.local",
-          "group": "sftp.trans@4"
+          "group": "sftp.trans@4",
+          "when": "sftp:enabled"
         }
       ],
       "editor/context": [
         {
           "command": "sftp.diff",
-          "group": "3_compare"
+          "group": "3_compare",
+          "when": "sftp:enabled"
         },
         {
           "command": "sftp.trans.remote",
-          "group": "sftp.trans@1"
+          "group": "sftp.trans@1",
+          "when": "sftp:enabled"
         },
         {
           "command": "sftp.trans.local",
-          "group": "sftp.trans@2"
+          "group": "sftp.trans@2",
+          "when": "sftp:enabled"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ import { initConfigs, loadConfig } from './modules/config';
 import { endAllRemote } from './modules/remoteFs';
 import { watchWorkspace, watchFiles, clearAllWatcher } from './modules/fileWatcher';
 import autoSave from './modules/autoSave';
-import { getWorkspaceFolders } from './host';
+import { getWorkspaceFolders, setContextValue } from './host';
 
 function registerCommand(
   context: vscode.ExtensionContext,
@@ -69,6 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
   setup()
     .then(_ => {
       output.status.msg('SFTP Ready', 1000 * 8);
+      setContextValue("enabled", true);
     })
     .catch(output.onError);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
   setup()
     .then(_ => {
       output.status.msg('SFTP Ready', 1000 * 8);
-      setContextValue("enabled", true);
+      setContextValue('enabled', true);
     })
     .catch(output.onError);
 }

--- a/src/host.ts
+++ b/src/host.ts
@@ -50,3 +50,7 @@ export function promptForPassword(prompt: string): Promise<string | null> {
     prompt,
   }) as Promise<string | null>;
 }
+
+export function setContextValue(key: string, value: any) {
+  vscode.commands.executeCommand("setContext", EXTENSION_NAME + ":" + key, value);
+}

--- a/src/host.ts
+++ b/src/host.ts
@@ -52,5 +52,5 @@ export function promptForPassword(prompt: string): Promise<string | null> {
 }
 
 export function setContextValue(key: string, value: any) {
-  vscode.commands.executeCommand("setContext", EXTENSION_NAME + ":" + key, value);
+  vscode.commands.executeCommand('setContext', EXTENSION_NAME + ':' + key, value);
 }


### PR DESCRIPTION
Inactive extensions for the current workspace tend to make menus needlessly long, this patch add a constant sftp:enabled used to hide menus when it isn't active (no sftp.json)