### PR TITLE
增加privateKeyPath的home路径(~/)的识别

### DIFF
--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -1,6 +1,7 @@
 import { CONFIG_PATH } from '../constants';
 import * as fse from 'fs-extra';
 import * as path from 'path';
+import * as os from 'os';
 import * as Joi from 'joi';
 import reportError from '../helper/reportError';
 import Trie from '../core/Trie';
@@ -106,7 +107,15 @@ function normalizeTriePath(pathname) {
   return path.normalize(pathname);
 }
 
+function normalizeHomePath(pathname) {
+  return pathname.substr(0, 2) === '~/' ? path.join(os.homedir(), pathname.slice(2)) : pathname
+}
+
 function addConfig(config, defaultContext) {
+  if (config.privateKeyPath) {
+    config.privateKeyPath = normalizeHomePath(config.privateKeyPath)
+  }
+
   const { error: validationError } = Joi.validate(config, configScheme, {
     convert: false,
     language: {


### PR DESCRIPTION
这样sftp.json文件可以被存入版本控制系统进行团队共享。

说明：
之所以在validate之前做normalizeHomePath，是希望路径变换之后的配置会被validate。