### PR TITLE
fix for #200, upload files from shortcut

### DIFF
--- a/src/modules/targetSelectStrategy.ts
+++ b/src/modules/targetSelectStrategy.ts
@@ -84,7 +84,7 @@ export function selectFileFallbackToConfigContext(item, items): Promise<FileTarg
   }
 
   // short cut
-  if (!item.fsPath) {
+  if (item === null || !item.fsPath) {
     return getActiveTarget();
   }
 

--- a/src/modules/targetSelectStrategy.ts
+++ b/src/modules/targetSelectStrategy.ts
@@ -117,7 +117,7 @@ export function selectFileOnly(item, items): Promise<FileTarget> {
   }
 
   // short cut
-  if (item === undefined || !item.fsPath) {
+  if (item === null || item === undefined || !item.fsPath) {
     return getActiveTarget();
   }
 


### PR DESCRIPTION
Fixing the error that was causing "Cannot read property 'fsPath' of null" error initiated from keyboard shortcut