### PR TITLE
Fix call signature error on ignore

### DIFF
--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -1,4 +1,4 @@
-import GitIgnore = require('ignore');
+import * as GitIgnore from 'ignore/ignore';
 
 export default class Ignore {
   static from(pattern) {


### PR DESCRIPTION
This PR fixes the call signature error in the ignore wrapper:

> Cannot invoke an expression whose type lacks a call signature. Type 'typeof import("vscode-sftp/node_modules/ignore/index")' has no compatible call signatures.